### PR TITLE
update install from source so git clone uses correct path

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pip install keras-rl2
 - Install from Github source:
 
 ```
-git clone https://github.com/keras-rl2/keras-rl2.git
+git clone https://github.com/wau/keras-rl2.git
 cd keras-rl
 python setup.py install
 ```


### PR DESCRIPTION
Relatively simple edit to the documentation. The current README references an incorrect, non-existent path when attempting to install from source. This pull request updates that path so that it correctly reaches the repository.