### PR TITLE
Fixed a bug that prevented separate actor and critic optimizers in DDPG.

### DIFF
--- a/rl/agents/ddpg.py
+++ b/rl/agents/ddpg.py
@@ -70,7 +70,6 @@ class DDPGAgent(Agent):
 
     def compile(self, optimizer, metrics=[]):
         metrics += [mean_q]
-        print(optimizer._name)
 
         if type(optimizer) in (list, tuple):
             if len(optimizer) != 2:


### PR DESCRIPTION
When using the DDPG agent with different optimizers for the actor and critic, an error occured in the deleted line, because lists and tuples have no attribute "_name".
