### PR TITLE
Python36+ code style

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,10 @@
+## Development
+
+### Running tests
+
+To run tests, you need to have all dependencies specified in `requirements-dev.txt` 
+(in addition to the user dependencies in setup.py). 
+Run `pip install -r requirements-dev.txt` to install them with pip.
+
+Now you should be able to launch tests using `pytest tests` 
+from the root folder.

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -111,7 +111,7 @@ def get_function_signature(function, method=True):
         args = args[:-len(defaults)]
     else:
         kwargs = []
-    st = '%s.%s(' % (function.__module__, function.__name__)
+    st = f'{function.__module__}.{function.__name__}('
     for a in args:
         st += str(a) + ', '
     for a, v in kwargs:

--- a/examples/cem_cartpole.py
+++ b/examples/cem_cartpole.py
@@ -55,7 +55,7 @@ cem.compile()
 cem.fit(env, nb_steps=100000, visualize=False, verbose=2)
 
 # After training is done, we save the best weights.
-cem.save_weights('cem_{}_params.h5f'.format(ENV_NAME), overwrite=True)
+cem.save_weights(f'cem_{ENV_NAME}_params.h5f', overwrite=True)
 
 # Finally, evaluate our algorithm for 5 episodes.
 cem.test(env, nb_episodes=5, visualize=True)

--- a/examples/ddpg_mujoco.py
+++ b/examples/ddpg_mujoco.py
@@ -23,7 +23,7 @@ ENV_NAME = 'HalfCheetah-v2'
 
 # Get the environment and extract the number of actions.
 env = gym.make(ENV_NAME)
-env = wrappers.Monitor(env, '/tmp/{}'.format(ENV_NAME), force=True)
+env = wrappers.Monitor(env, f'/tmp/{ENV_NAME}', force=True)
 np.random.seed(123)
 env.seed(123)
 assert len(env.action_space.shape) == 1
@@ -69,7 +69,7 @@ agent.compile([Adam(lr=1e-4), Adam(lr=1e-3)], metrics=['mae'])
 agent.fit(env, nb_steps=1000000, visualize=False, verbose=1)
 
 # After training is done, we save the final weights.
-agent.save_weights('ddpg_{}_weights.h5f'.format(ENV_NAME), overwrite=True)
+agent.save_weights(f'ddpg_{ENV_NAME}_weights.h5f', overwrite=True)
 
 # Finally, evaluate our algorithm for 5 episodes.
 agent.test(env, nb_episodes=5, visualize=True, nb_max_episode_steps=200)

--- a/examples/ddpg_pendulum.py
+++ b/examples/ddpg_pendulum.py
@@ -63,7 +63,7 @@ agent.compile(Adam(lr=.001, clipnorm=1.), metrics=['mae'])
 agent.fit(env, nb_steps=50000, visualize=True, verbose=1, nb_max_episode_steps=200)
 
 # After training is done, we save the final weights.
-agent.save_weights('ddpg_{}_weights.h5f'.format(ENV_NAME), overwrite=True)
+agent.save_weights(f'ddpg_{ENV_NAME}_weights.h5f', overwrite=True)
 
 # Finally, evaluate our algorithm for 5 episodes.
 agent.test(env, nb_episodes=5, visualize=True, nb_max_episode_steps=200)

--- a/examples/dqn_atari.py
+++ b/examples/dqn_atari.py
@@ -99,9 +99,9 @@ dqn.compile(Adam(lr=.00025), metrics=['mae'])
 if args.mode == 'train':
     # Okay, now it's time to learn something! We capture the interrupt exception so that training
     # can be prematurely aborted. Notice that now you can use the built-in tensorflow.keras callbacks!
-    weights_filename = 'dqn_{}_weights.h5f'.format(args.env_name)
+    weights_filename = f'dqn_{args.env_name}_weights.h5f'
     checkpoint_weights_filename = 'dqn_' + args.env_name + '_weights_{step}.h5f'
-    log_filename = 'dqn_{}_log.json'.format(args.env_name)
+    log_filename = f'dqn_{args.env_name}_log.json'
     callbacks = [ModelIntervalCheckpoint(checkpoint_weights_filename, interval=250000)]
     callbacks += [FileLogger(log_filename, interval=100)]
     dqn.fit(env, callbacks=callbacks, nb_steps=1750000, log_interval=10000)
@@ -112,7 +112,7 @@ if args.mode == 'train':
     # Finally, evaluate our algorithm for 10 episodes.
     dqn.test(env, nb_episodes=10, visualize=False)
 elif args.mode == 'test':
-    weights_filename = 'dqn_{}_weights.h5f'.format(args.env_name)
+    weights_filename = f'dqn_{args.env_name}_weights.h5f'
     if args.weights:
         weights_filename = args.weights
     dqn.load_weights(weights_filename)

--- a/examples/dqn_cartpole.py
+++ b/examples/dqn_cartpole.py
@@ -46,7 +46,7 @@ dqn.compile(Adam(lr=1e-3), metrics=['mae'])
 dqn.fit(env, nb_steps=50000, visualize=True, verbose=2)
 
 # After training is done, we save the final weights.
-dqn.save_weights('dqn_{}_weights.h5f'.format(ENV_NAME), overwrite=True)
+dqn.save_weights(f'dqn_{ENV_NAME}_weights.h5f', overwrite=True)
 
 # Finally, evaluate our algorithm for 5 episodes.
 dqn.test(env, nb_episodes=5, visualize=True)

--- a/examples/duel_dqn_cartpole.py
+++ b/examples/duel_dqn_cartpole.py
@@ -49,7 +49,7 @@ dqn.compile(Adam(lr=1e-3), metrics=['mae'])
 dqn.fit(env, nb_steps=50000, visualize=False, verbose=2)
 
 # After training is done, we save the final weights.
-dqn.save_weights('duel_dqn_{}_weights.h5f'.format(ENV_NAME), overwrite=True)
+dqn.save_weights(f'duel_dqn_{ENV_NAME}_weights.h5f', overwrite=True)
 
 # Finally, evaluate our algorithm for 5 episodes.
 dqn.test(env, nb_episodes=5, visualize=False)

--- a/examples/naf_pendulum.py
+++ b/examples/naf_pendulum.py
@@ -61,7 +61,7 @@ x = Dense(32)(x)
 x = Activation('relu')(x)
 x = Dense(32)(x)
 x = Activation('relu')(x)
-x = Dense(((nb_actions * nb_actions + nb_actions) // 2))(x)
+x = Dense((nb_actions * nb_actions + nb_actions) // 2)(x)
 x = Activation('linear')(x)
 L_model = Model(inputs=[action_input, observation_input], outputs=x)
 print(L_model.summary())
@@ -82,7 +82,7 @@ agent.compile(Adam(lr=.001, clipnorm=1.), metrics=['mae'])
 agent.fit(env, nb_steps=50000, visualize=True, verbose=1, nb_max_episode_steps=200)
 
 # After training is done, we save the final weights.
-agent.save_weights('cdqn_{}_weights.h5f'.format(ENV_NAME), overwrite=True)
+agent.save_weights(f'cdqn_{ENV_NAME}_weights.h5f', overwrite=True)
 
 # Finally, evaluate our algorithm for 5 episodes.
 agent.test(env, nb_episodes=10, visualize=True, nb_max_episode_steps=200)

--- a/examples/sarsa_cartpole.py
+++ b/examples/sarsa_cartpole.py
@@ -41,7 +41,7 @@ sarsa.compile(Adam(lr=1e-3), metrics=['mae'])
 sarsa.fit(env, nb_steps=50000, visualize=False, verbose=2)
 
 # After training is done, we save the final weights.
-sarsa.save_weights('sarsa_{}_weights.h5f'.format(ENV_NAME), overwrite=True)
+sarsa.save_weights(f'sarsa_{ENV_NAME}_weights.h5f', overwrite=True)
 
 # Finally, evaluate our algorithm for 5 episodes.
 sarsa.test(env, nb_episodes=5, visualize=True)

--- a/examples/visualize_log.py
+++ b/examples/visualize_log.py
@@ -8,11 +8,11 @@ def visualize_log(filename, figsize=None, output=None):
     with open(filename, 'r') as f:
         data = json.load(f)
     if 'episode' not in data:
-        raise ValueError('Log file "{}" does not contain the "episode" key.'.format(filename))
+        raise ValueError(f'Log file "{filename}" does not contain the "episode" key.')
     episodes = data['episode']
 
     # Get value keys. The x axis is shared and is the number of episodes.
-    keys = sorted(list(set(data.keys()).difference(set(['episode']))))
+    keys = sorted(list(set(data.keys()).difference({'episode'})))
 
     if figsize is None:
         figsize = (15., 5. * len(keys))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # Configuration of py.test
 [pytest]
 addopts=-v
-        -n 2
+        -n 4
         --durations=10
 
 # Do not run tests in the build folder or in the virtualenv folder `venv`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-xdist
+gym

--- a/rl/agents/__init__.py
+++ b/rl/agents/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .dqn import DQNAgent, NAFAgent, ContinuousDQNAgent
 from .ddpg import DDPGAgent
 from .cem import CEMAgent

--- a/rl/agents/cem.py
+++ b/rl/agents/cem.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from collections import deque
 from copy import deepcopy
 
@@ -15,7 +14,7 @@ class CEMAgent(Agent):
     def __init__(self, model, nb_actions, memory, batch_size=50, nb_steps_warmup=1000,
                  train_interval=50, elite_frac=0.05, memory_interval=1, theta_init=None,
                  noise_decay_const=0.0, noise_ampl=0.0, **kwargs):
-        super(CEMAgent, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # Parameters.
         self.nb_actions = nb_actions
@@ -96,7 +95,7 @@ class CEMAgent(Agent):
     
     def update_theta(self,theta):
         if (theta is not None):
-            assert theta.shape == self.theta.shape, "Invalid theta, shape is {0} but should be {1}".format(theta.shape,self.theta.shape)
+            assert theta.shape == self.theta.shape, f"Invalid theta, shape is {theta.shape} but should be {self.theta.shape}"
             assert (not np.isnan(theta).any()), "Invalid theta, NaN encountered"
             assert (theta[self.num_weights:] >= 0.).all(), "Invalid theta, standard deviations must be nonnegative"            
             self.theta = theta

--- a/rl/agents/ddpg.py
+++ b/rl/agents/ddpg.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from collections import deque
 import os
 import warnings
@@ -28,7 +27,7 @@ class DDPGAgent(Agent):
                  gamma=.99, batch_size=32, nb_steps_warmup_critic=1000, nb_steps_warmup_actor=1000,
                  train_interval=1, memory_interval=1, delta_range=None, delta_clip=np.inf,
                  random_process=None, custom_model_objects={}, target_model_update=.001, **kwargs):
-        super(DDPGAgent, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # Soft vs hard target model updates.
         if target_model_update < 0:

--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import warnings
 
 import tensorflow.keras.backend as K
@@ -20,7 +19,7 @@ class AbstractDQNAgent(Agent):
     def __init__(self, nb_actions, memory, gamma=.99, batch_size=32, nb_steps_warmup=1000,
                  train_interval=1, memory_interval=1, target_model_update=10000,
                  delta_range=None, delta_clip=np.inf, custom_model_objects={}, **kwargs):
-        super(AbstractDQNAgent, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # Soft vs hard target model updates.
         if target_model_update < 0:
@@ -101,11 +100,11 @@ class DQNAgent(AbstractDQNAgent):
     """
     def __init__(self, model, policy=None, test_policy=None, enable_double_dqn=False, enable_dueling_network=False,
                  dueling_type='avg', *args, **kwargs):
-        super(DQNAgent, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Validate (important) input.
         if list(model.output.shape) != list((None, self.nb_actions)):
-            raise ValueError('Model output "{}" has invalid shape. DQN expects a model that has one dimension for each action, in this case {}.'.format(model.output, self.nb_actions))
+            raise ValueError(f'Model output "{model.output}" has invalid shape. DQN expects a model that has one dimension for each action, in this case {self.nb_actions}.')
 
         # Parameters.
         self.enable_double_dqn = enable_double_dqn
@@ -150,7 +149,7 @@ class DQNAgent(AbstractDQNAgent):
         self.reset_states()
 
     def get_config(self):
-        config = super(DQNAgent, self).get_config()
+        config = super().get_config()
         config['enable_double_dqn'] = self.enable_double_dqn
         config['dueling_type'] = self.dueling_type
         config['enable_dueling_network'] = self.enable_dueling_network
@@ -371,11 +370,11 @@ class NAFLayer(Layer):
     """
     def __init__(self, nb_actions, mode='full', **kwargs):
         if mode not in ('full', 'diag'):
-            raise RuntimeError('Unknown mode "{}" in NAFLayer.'.format(self.mode))
+            raise RuntimeError(f'Unknown mode "{self.mode}" in NAFLayer.')
 
         self.nb_actions = nb_actions
         self.mode = mode
-        super(NAFLayer, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def call(self, x, mask=None):
         # TODO: validate input shape
@@ -464,7 +463,7 @@ class NAFLayer(Layer):
                     L = tmp[:, 0, :, :]
                     LT = tmp[:, 1, :, :]
             else:
-                raise RuntimeError('Unknown Keras backend "{}".'.format(K.backend()))
+                raise RuntimeError(f'Unknown Keras backend "{K.backend()}".')
             assert L is not None
             assert LT is not None
             P = K.batch_dot(L, LT)
@@ -508,7 +507,7 @@ class NAFLayer(Layer):
 
                 P = tf.scan(fn, L_flat, initializer=K.zeros((self.nb_actions, self.nb_actions)))
             else:
-                raise RuntimeError('Unknown Keras backend "{}".'.format(K.backend()))
+                raise RuntimeError(f'Unknown Keras backend "{K.backend()}".')
         assert P is not None
         assert K.ndim(P) == 3
 
@@ -531,7 +530,7 @@ class NAFLayer(Layer):
             raise RuntimeError("Expects 3 inputs: L, mu, a")
         for i, shape in enumerate(input_shape):
             if len(shape) != 2:
-                raise RuntimeError("Input {} has {} dimensions but should have 2".format(i, len(shape)))
+                raise RuntimeError(f"Input {i} has {len(shape)} dimensions but should have 2")
         assert self.mode in ('full','diag')
         if self.mode == 'full':
             expected_elements = (self.nb_actions * self.nb_actions + self.nb_actions) // 2
@@ -544,10 +543,10 @@ class NAFLayer(Layer):
             raise RuntimeError("Input 0 (L) should have {} elements but has {}".format(input_shape[0][1]))
         if input_shape[1][1] != self.nb_actions:
             raise RuntimeError(
-                "Input 1 (mu) should have {} elements but has {}".format(self.nb_actions, input_shape[1][1]))
+                f"Input 1 (mu) should have {self.nb_actions} elements but has {input_shape[1][1]}")
         if input_shape[2][1] != self.nb_actions:
             raise RuntimeError(
-                "Input 2 (action) should have {} elements but has {}".format(self.nb_actions, input_shape[1][1]))
+                f"Input 2 (action) should have {self.nb_actions} elements but has {input_shape[1][1]}")
         return input_shape[0][0], 1
 
 
@@ -556,7 +555,7 @@ class NAFAgent(AbstractDQNAgent):
     """
     def __init__(self, V_model, L_model, mu_model, random_process=None,
                  covariance_mode='full', *args, **kwargs):
-        super(NAFAgent, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # TODO: Validate (important) input.
 
@@ -604,7 +603,7 @@ class NAFAgent(AbstractDQNAgent):
             observation_shapes = [i.shape[1:] for i in self.V_model.input]
         else:
             observation_shapes = [self.V_model.input.shape[1:]]
-        os_in = [Input(shape=shape, name='observation_input_{}'.format(idx)) for idx, shape in enumerate(observation_shapes)]
+        os_in = [Input(shape=shape, name=f'observation_input_{idx}') for idx, shape in enumerate(observation_shapes)]
         L_out = self.L_model([a_in] + os_in)
         V_out = self.V_model(os_in)
 
@@ -720,7 +719,7 @@ class NAFAgent(AbstractDQNAgent):
         return self.combined_model.layers[:]
 
     def get_config(self):
-        config = super(NAFAgent, self).get_config()
+        config = super().get_config()
         config['V_model'] = get_object_config(self.V_model)
         config['mu_model'] = get_object_config(self.mu_model)
         config['L_model'] = get_object_config(self.L_model)

--- a/rl/callbacks.py
+++ b/rl/callbacks.py
@@ -1,5 +1,3 @@
-from __future__ import division
-from __future__ import print_function
 import warnings
 import timeit
 import json
@@ -104,7 +102,7 @@ class TestLogger(Callback):
     """ Logger Class for Test """
     def on_train_begin(self, logs):
         """ Print logs at beginning of training"""
-        print('Testing for {} episodes ...'.format(self.params['nb_episodes']))
+        print(f"Testing for {self.params['nb_episodes']} episodes ...")
 
     def on_episode_end(self, episode, logs):
         """ Print logs at end of each episode """
@@ -133,12 +131,12 @@ class TrainEpisodeLogger(Callback):
         """ Print training values at beginning of training """
         self.train_start = timeit.default_timer()
         self.metrics_names = self.model.metrics_names
-        print('Training for {} steps ...'.format(self.params['nb_steps']))
+        print(f"Training for {self.params['nb_steps']} steps ...")
         
     def on_train_end(self, logs):
         """ Print training time at end of training """
         duration = timeit.default_timer() - self.train_start
-        print('done, took {:.3f} seconds'.format(duration))
+        print(f'done, took {duration:.3f} seconds')
 
     def on_episode_begin(self, episode, logs):
         """ Reset environment variables at beginning of each episode """
@@ -227,12 +225,12 @@ class TrainIntervalLogger(Callback):
         """ Initialize training statistics at beginning of training """
         self.train_start = timeit.default_timer()
         self.metrics_names = self.model.metrics_names
-        print('Training for {} steps ...'.format(self.params['nb_steps']))
+        print(f"Training for {self.params['nb_steps']} steps ...")
 
     def on_train_end(self, logs):
         """ Print training duration at end of training """
         duration = timeit.default_timer() - self.train_start
-        print('done, took {:.3f} seconds'.format(duration))
+        print(f'done, took {duration:.3f} seconds')
 
     def on_step_begin(self, step, logs):
         """ Print metrics if interval is over """
@@ -245,7 +243,7 @@ class TrainIntervalLogger(Callback):
                     means = np.nanmean(self.metrics, axis=0)
                     assert means.shape == (len(self.metrics_names),)
                     for name, mean in zip(self.metrics_names, means):
-                        formatted_metrics += ' - {}: {:.3f}'.format(name, mean)
+                        formatted_metrics += f' - {name}: {mean:.3f}'
                 
                 formatted_infos = ''
                 if len(self.infos) > 0:
@@ -254,11 +252,11 @@ class TrainIntervalLogger(Callback):
                         means = np.nanmean(self.infos, axis=0)
                         assert means.shape == (len(self.info_names),)
                         for name, mean in zip(self.info_names, means):
-                            formatted_infos += ' - {}: {:.3f}'.format(name, mean)
-                print('{} episodes - episode_reward: {:.3f} [{:.3f}, {:.3f}]{}{}'.format(len(self.episode_rewards), np.mean(self.episode_rewards), np.min(self.episode_rewards), np.max(self.episode_rewards), formatted_metrics, formatted_infos))
+                            formatted_infos += f' - {name}: {mean:.3f}'
+                print(f'{len(self.episode_rewards)} episodes - episode_reward: {np.mean(self.episode_rewards):.3f} [{np.min(self.episode_rewards):.3f}, {np.max(self.episode_rewards):.3f}]{formatted_metrics}{formatted_infos}')
                 print('')
             self.reset()
-            print('Interval {} ({} steps performed)'.format(self.step // self.interval + 1, self.step))
+            print(f'Interval {self.step // self.interval + 1} ({self.step} steps performed)')
 
     def on_step_end(self, step, logs):
         """ Update progression bar at the end of each step """
@@ -364,7 +362,7 @@ class Visualizer(Callback):
 
 class ModelIntervalCheckpoint(Callback):
     def __init__(self, filepath, interval, verbose=0):
-        super(ModelIntervalCheckpoint, self).__init__()
+        super().__init__()
         self.filepath = filepath
         self.interval = interval
         self.verbose = verbose
@@ -379,5 +377,5 @@ class ModelIntervalCheckpoint(Callback):
 
         filepath = self.filepath.format(step=self.total_steps, **logs)
         if self.verbose > 0:
-            print('Step {}: saving model to {}'.format(self.total_steps, filepath))
+            print(f'Step {self.total_steps}: saving model to {filepath}')
         self.model.save_weights(filepath, overwrite=True)

--- a/rl/common/vec_env/__init__.py
+++ b/rl/common/vec_env/__init__.py
@@ -1,6 +1,6 @@
 # Inspired from VecEnv from OpenAI Baselines
 
-class VecEnv(object):
+class VecEnv:
     """
     An abstract asynchronous, vectorized environment.
     """
@@ -52,7 +52,7 @@ class VecEnv(object):
         return self.step_wait()
 
     def render(self, mode='human'):
-        logger.warn('Render not defined for %s' % self)
+        logger.warn(f'Render not defined for {self}')
 
     def seed(self, i):
         raise NotImplementedError()
@@ -64,7 +64,7 @@ class VecEnv(object):
         else:
             return self
 
-class CloudpickleWrapper(object):
+class CloudpickleWrapper:
     """
     Uses cloudpickle to serialize contents (otherwise multiprocessing tries to use pickle)
     """

--- a/rl/core.py
+++ b/rl/core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import warnings
 from copy import deepcopy
 
@@ -14,7 +13,7 @@ from rl.callbacks import (
 )
 
 
-class Agent(object):
+class Agent:
     """Abstract base class for all implemented agents.
 
     Each agent interacts with the environment (as defined by the `Env` class) by first observing the
@@ -84,7 +83,7 @@ class Agent(object):
         if not self.compiled:
             raise RuntimeError('Your tried to fit your agent but it hasn\'t been compiled yet. Please call `compile()` before `fit()`.')
         if action_repetition < 1:
-            raise ValueError('action_repetition must be >= 1, is {}'.format(action_repetition))
+            raise ValueError(f'action_repetition must be >= 1, is {action_repetition}')
 
         self.training = True
 
@@ -151,7 +150,7 @@ class Agent(object):
                             observation, reward, done, info = self.processor.process_step(observation, reward, done, info)
                         callbacks.on_action_end(action)
                         if done:
-                            warnings.warn('Env ended before {} random steps could be performed at the start. You should probably lower the `nb_max_start_steps` parameter.'.format(nb_random_start_steps))
+                            warnings.warn(f'Env ended before {nb_random_start_steps} random steps could be performed at the start. You should probably lower the `nb_max_start_steps` parameter.')
                             observation = deepcopy(env.reset())
                             if self.processor is not None:
                                 observation = self.processor.process_observation(observation)
@@ -270,7 +269,7 @@ class Agent(object):
         if not self.compiled:
             raise RuntimeError('Your tried to test your agent but it hasn\'t been compiled yet. Please call `compile()` before `test()`.')
         if action_repetition < 1:
-            raise ValueError('action_repetition must be >= 1, is {}'.format(action_repetition))
+            raise ValueError(f'action_repetition must be >= 1, is {action_repetition}')
 
         self.training = False
         self.step = 0
@@ -328,7 +327,7 @@ class Agent(object):
                     observation, r, done, info = self.processor.process_step(observation, r, done, info)
                 callbacks.on_action_end(action)
                 if done:
-                    warnings.warn('Env ended before {} random steps could be performed at the start. You should probably lower the `nb_max_start_steps` parameter.'.format(nb_random_start_steps))
+                    warnings.warn(f'Env ended before {nb_random_start_steps} random steps could be performed at the start. You should probably lower the `nb_max_start_steps` parameter.')
                     observation = deepcopy(env.reset())
                     if self.processor is not None:
                         observation = self.processor.process_observation(observation)
@@ -495,7 +494,7 @@ class Agent(object):
         pass
 
 
-class Processor(object):
+class Processor:
     """Abstract base class for implementing processors.
 
     A processor acts as a coupling mechanism between an `Agent` and its `Env`. This can
@@ -604,7 +603,7 @@ class Processor(object):
 # https://github.com/openai/gym/blob/master/gym/core.py
 
 
-class Env(object):
+class Env:
     """The abstract environment class that is used by all agents. This class has the exact
     same API that OpenAI Gym uses so that integrating with it is trivial. In contrast to the
     OpenAI Gym implementation, this class only defines the abstract methods without any actual
@@ -686,10 +685,10 @@ class Env(object):
         self.close()
 
     def __str__(self):
-        return '<{} instance>'.format(type(self).__name__)
+        return f'<{type(self).__name__} instance>'
 
 
-class Space(object):
+class Space:
     """Abstract model for a space that is used for the state and action spaces. This class has the
     exact same API that OpenAI Gym uses so that integrating with it is trivial.
 

--- a/rl/memory.py
+++ b/rl/memory.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from collections import deque, namedtuple
 import warnings
 import random
@@ -43,7 +42,7 @@ def sample_batch_indexes(low, high, size):
     return batch_idxs
 
 
-class RingBuffer(object):
+class RingBuffer:
     def __init__(self, maxlen):
         self.maxlen = maxlen
         self.data = deque(maxlen=maxlen)
@@ -109,7 +108,7 @@ def zeroed_observation(observation):
         return 0.
 
 
-class Memory(object):
+class Memory:
     def __init__(self, window_length, ignore_episode_boundaries=False):
         self.window_length = window_length
         self.ignore_episode_boundaries = ignore_episode_boundaries
@@ -164,7 +163,7 @@ class Memory(object):
 
 class SequentialMemory(Memory):
     def __init__(self, limit, **kwargs):
-        super(SequentialMemory, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         
         self.limit = limit
 
@@ -254,7 +253,7 @@ class SequentialMemory(Memory):
             reward (float): Reward obtained by taking this action
             terminal (boolean): Is the state terminal
         """ 
-        super(SequentialMemory, self).append(observation, action, reward, terminal, training=training)
+        super().append(observation, action, reward, terminal, training=training)
         
         # This needs to be understood as follows: in `observation`, take `action`, obtain `reward`
         # and weather the next state is `terminal` or not.
@@ -279,14 +278,14 @@ class SequentialMemory(Memory):
         # Returns
             Dict of config
         """
-        config = super(SequentialMemory, self).get_config()
+        config = super().get_config()
         config['limit'] = self.limit
         return config
 
 
 class EpisodeParameterMemory(Memory):
     def __init__(self, limit, **kwargs):
-        super(EpisodeParameterMemory, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.limit = limit
 
         self.params = RingBuffer(limit)
@@ -322,7 +321,7 @@ class EpisodeParameterMemory(Memory):
             reward (float): Reward obtained by taking this action
             terminal (boolean): Is the state terminal
         """
-        super(EpisodeParameterMemory, self).append(observation, action, reward, terminal, training=training)
+        super().append(observation, action, reward, terminal, training=training)
         if training:
             self.intermediate_rewards.append(reward)
 

--- a/rl/policy.py
+++ b/rl/policy.py
@@ -1,10 +1,9 @@
-from __future__ import division
 import numpy as np
 
 from rl.util import *
 
 
-class Policy(object):
+class Policy:
     """Abstract base class for all implemented policies.
 
     Each policy helps with selection of action to take on an environment.
@@ -48,9 +47,9 @@ class LinearAnnealedPolicy(Policy):
     value is following a linear function decreasing over time."""
     def __init__(self, inner_policy, attr, value_max, value_min, value_test, nb_steps):
         if not hasattr(inner_policy, attr):
-            raise ValueError('Policy does not have attribute "{}".'.format(attr))
+            raise ValueError(f'Policy does not have attribute "{attr}".')
 
-        super(LinearAnnealedPolicy, self).__init__()
+        super().__init__()
 
         self.inner_policy = inner_policy
         self.attr = attr
@@ -90,7 +89,7 @@ class LinearAnnealedPolicy(Policy):
         # Returns
             List of metric names
         """
-        return ['mean_{}'.format(self.attr)]
+        return [f'mean_{self.attr}']
 
     @property
     def metrics(self):
@@ -108,7 +107,7 @@ class LinearAnnealedPolicy(Policy):
         # Returns
             Dict of config
         """
-        config = super(LinearAnnealedPolicy, self).get_config()
+        config = super().get_config()
         config['attr'] = self.attr
         config['value_max'] = self.value_max
         config['value_min'] = self.value_min
@@ -147,7 +146,7 @@ class EpsGreedyQPolicy(Policy):
     - takes current best action with prob (1 - epsilon)
     """
     def __init__(self, eps=.1):
-        super(EpsGreedyQPolicy, self).__init__()
+        super().__init__()
         self.eps = eps
 
     def select_action(self, q_values):
@@ -174,7 +173,7 @@ class EpsGreedyQPolicy(Policy):
         # Returns
             Dict of config
         """
-        config = super(EpsGreedyQPolicy, self).get_config()
+        config = super().get_config()
         config['eps'] = self.eps
         return config
 
@@ -205,7 +204,7 @@ class BoltzmannQPolicy(Policy):
     an action selected randomly according to this law.
     """
     def __init__(self, tau=1., clip=(-500., 500.)):
-        super(BoltzmannQPolicy, self).__init__()
+        super().__init__()
         self.tau = tau
         self.clip = clip
 
@@ -233,7 +232,7 @@ class BoltzmannQPolicy(Policy):
         # Returns
             Dict of config
         """
-        config = super(BoltzmannQPolicy, self).get_config()
+        config = super().get_config()
         config['tau'] = self.tau
         config['clip'] = self.clip
         return config
@@ -249,7 +248,7 @@ class MaxBoltzmannQPolicy(Policy):
     https://pure.uva.nl/ws/files/3153478/8461_UBA003000033.pdf
     """
     def __init__(self, eps=.1, tau=1., clip=(-500., 500.)):
-        super(MaxBoltzmannQPolicy, self).__init__()
+        super().__init__()
         self.eps = eps
         self.tau = tau
         self.clip = clip
@@ -283,7 +282,7 @@ class MaxBoltzmannQPolicy(Policy):
         # Returns
             Dict of config
         """
-        config = super(MaxBoltzmannQPolicy, self).get_config()
+        config = super().get_config()
         config['eps'] = self.eps
         config['tau'] = self.tau
         config['clip'] = self.clip
@@ -307,7 +306,7 @@ class BoltzmannGumbelQPolicy(Policy):
 
     def __init__(self, C=1.0):
         assert C > 0, "BoltzmannGumbelQPolicy C parameter must be > 0, not " + repr(C)
-        super(BoltzmannGumbelQPolicy, self).__init__()
+        super().__init__()
         self.C = C
         self.action_counts = None
 
@@ -351,6 +350,6 @@ class BoltzmannGumbelQPolicy(Policy):
         # Returns
             Dict of config
         """
-        config = super(BoltzmannGumbelQPolicy, self).get_config()
+        config = super().get_config()
         config['C'] = self.C
         return config

--- a/rl/random.py
+++ b/rl/random.py
@@ -1,8 +1,7 @@
-from __future__ import division
 import numpy as np
 
 
-class RandomProcess(object):
+class RandomProcess:
     def reset_states(self):
         pass
 
@@ -30,7 +29,7 @@ class AnnealedGaussianProcess(RandomProcess):
 
 class GaussianWhiteNoiseProcess(AnnealedGaussianProcess):
     def __init__(self, mu=0., sigma=1., sigma_min=None, n_steps_annealing=1000, size=1):
-        super(GaussianWhiteNoiseProcess, self).__init__(mu=mu, sigma=sigma, sigma_min=sigma_min, n_steps_annealing=n_steps_annealing)
+        super().__init__(mu=mu, sigma=sigma, sigma_min=sigma_min, n_steps_annealing=n_steps_annealing)
         self.size = size
 
     def sample(self):
@@ -41,7 +40,7 @@ class GaussianWhiteNoiseProcess(AnnealedGaussianProcess):
 # Based on http://math.stackexchange.com/questions/1287634/implementing-ornstein-uhlenbeck-in-matlab
 class OrnsteinUhlenbeckProcess(AnnealedGaussianProcess):
     def __init__(self, theta, mu=0., sigma=1., dt=1e-2, size=1, sigma_min=None, n_steps_annealing=1000):
-        super(OrnsteinUhlenbeckProcess, self).__init__(mu=mu, sigma=sigma, sigma_min=sigma_min, n_steps_annealing=n_steps_annealing)
+        super().__init__(mu=mu, sigma=sigma, sigma_min=sigma_min, n_steps_annealing=n_steps_annealing)
         self.theta = theta
         self.mu = mu
         self.dt = dt

--- a/rl/util.py
+++ b/rl/util.py
@@ -22,7 +22,7 @@ def clone_optimizer(optimizer):
         print(optimizer)
         return optimizers.get(optimizer)
     # Requires Keras 1.0.7 since get_config has breaking changes.
-    params = dict([(k, v) for k, v in optimizer.get_config().items()])
+    params = {k: v for k, v in optimizer.get_config().items()}
     config = {
         'class_name': optimizer.__class__.__name__,
         'config': params,
@@ -98,7 +98,7 @@ class AdditionalUpdatesOptimizer(optimizers.Optimizer):
 
 
 # Based on https://github.com/openai/baselines/blob/master/baselines/common/mpi_running_mean_std.py
-class WhiteningNormalizer(object):
+class WhiteningNormalizer:
     def __init__(self, shape, eps=1e-2, dtype=np.float64):
         self.eps = eps
         self.shape = shape

--- a/tests/integration/test_continuous.py
+++ b/tests/integration/test_continuous.py
@@ -37,7 +37,7 @@ def test_cdqn():
     x = Concatenate()([action_input, Flatten()(observation_input)])
     x = Dense(16)(x)
     x = Activation('relu')(x)
-    x = Dense(((nb_actions * nb_actions + nb_actions) // 2))(x)
+    x = Dense((nb_actions * nb_actions + nb_actions) // 2)(x)
     L_model = Model(inputs=[action_input, observation_input], outputs=x)
 
     memory = SequentialMemory(limit=1000, window_length=1)

--- a/tests/rl/agents/__init__.py
+++ b/tests/rl/agents/__init__.py
@@ -1,5 +1,0 @@
-from __future__ import absolute_import
-from .dqn import DQNAgent, NAFAgent, ContinuousDQNAgent
-from .ddpg import DDPGAgent
-from .cem import CEMAgent
-from .sarsa import SarsaAgent, SARSAAgent

--- a/tests/rl/agents/test_cem.py
+++ b/tests/rl/agents/test_cem.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import absolute_import
-
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose

--- a/tests/rl/agents/test_ddpg.py
+++ b/tests/rl/agents/test_ddpg.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import absolute_import
-
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose

--- a/tests/rl/agents/test_dqn.py
+++ b/tests/rl/agents/test_dqn.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import absolute_import
-
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -59,7 +56,7 @@ def test_single_continuous_dqn_input():
     L_input = Input(shape=(2, 3))
     L_input_action = Input(shape=(nb_actions,))
     x = Concatenate()([Flatten()(L_input), L_input_action])
-    x = Dense(((nb_actions * nb_actions + nb_actions) // 2))(x)
+    x = Dense((nb_actions * nb_actions + nb_actions) // 2)(x)
     L_model = Model(inputs=[L_input_action, L_input], outputs=x)
 
     memory = SequentialMemory(limit=10, window_length=2)
@@ -91,7 +88,7 @@ def test_multi_continuous_dqn_input():
     L_input_action = Input(shape=(nb_actions,))
     x = Concatenate()([L_input1, L_input2])
     x = Concatenate()([Flatten()(x), L_input_action])
-    x = Dense(((nb_actions * nb_actions + nb_actions) // 2))(x)
+    x = Dense((nb_actions * nb_actions + nb_actions) // 2)(x)
     L_model = Model(inputs=[L_input_action, L_input1, L_input2], outputs=x)
 
     memory = SequentialMemory(limit=10, window_length=2)

--- a/tests/rl/test_core.py
+++ b/tests/rl/test_core.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -9,7 +8,7 @@ from rl.core import Agent, Env, Processor
 
 class TestEnv(Env):
     def __init__(self):
-        super(TestEnv, self).__init__()
+        super().__init__()
 
     def step(self, action):
         self.state += 1
@@ -30,7 +29,7 @@ class TestEnv(Env):
 
 class TestAgent(Agent):
     def __init__(self, memory, **kwargs):
-        super(TestAgent, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.memory = memory
 
     def forward(self, observation):
@@ -105,7 +104,7 @@ def test_copy_observations():
 
         class LocalEnv(Env):
             def __init__(self):
-                super(LocalEnv, self).__init__()
+                super().__init__()
 
             def step(self, action):
                 self.state += 1

--- a/tests/rl/test_memory.py
+++ b/tests/rl/test_memory.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose

--- a/tests/rl/test_util.py
+++ b/tests/rl/test_util.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose


### PR DESCRIPTION
This PR changes the code style to use idioms of Python36+ - the changes are derived by running `pyupgrade --py36-plus` and `flynt`. Migrating to py36+ makes sense because python versions below py36 are not supported by tensorflow 2.1+, therefore they already can't be used.

Tests are passing.